### PR TITLE
Add an upgrade error if the plugin cannot load classes in upgrade

### DIFF
--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1926,6 +1926,15 @@ class PluginGenericobjectType extends CommonDBTM {
 
       $notepad = new Notepad();
       foreach ($allGenericObjectTypes as $genericObjectType => $genericObjectData) {
+         $itemtype = $genericObjectData['itemtype'];
+         if (! class_exists($itemtype, true)) {
+            // TRANS:  %1$s is itemtype name
+            $warning  = sprintf(__('Unable to load the class %1$s.', 'genericobject'), $itemtype);
+            // TRANS:  %1$s is itemtype name
+            $warning .= sprintf(__('You probably have garbage data in your database for this plugin and missing files in %1$s', 'genericobject'), GENERICOBJECT_DOC_DIR);
+            $migration->displayWarning($warning, true);
+            die();
+         }
          $genericObjectTypeInstance = new $genericObjectType();
          if (FieldExists($genericObjectTypeInstance->getTable(), "notepad")) {
             $query = "INSERT INTO `" . $notepad->getTable() . "`


### PR DESCRIPTION
Many users have trouble to upgrade their GLPi because  they miss or forget to copy files of the plugin from a old to new instance of GLPi.

I hope this will help them to solve the issue by themselve, help them faster, and produce less support request.

Maybe this would be a good idea to add an hyperlink to a help page.

See #113 