### PR TITLE
Fix rights matrix display for object; fixes #182

### DIFF
--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -76,23 +76,22 @@ class PluginGenericobjectProfile extends Profile {
       echo "</strong></th></tr>";
 
       echo "<tr><td class='genericobject_type_profiles'>";
-      $rights = [];
       foreach (getAllDatasFromTable(getTableForItemtype("Profile")) as $profile) {
          $prof = new Profile();
          $prof->getFromDB($profile['id']);
-         $right = self::getProfileforItemtype($profile['id'], $itemtype);
-         $label = $profile['name'];
-         $rights[] = [
-            'label' => $label,
-            'itemtype' => $itemtype,
-            'field' =>  self::getProfileNameForItemtype($itemtype),
-            'html_field' => "profile_" . $profile['id'],
+         $rights = [
+            [
+               'label' => $profile['name'],
+               'itemtype' => $itemtype,
+               'field' =>  self::getProfileNameForItemtype($itemtype),
+               'html_field' => "profile_" . $profile['id'],
+            ]
          ];
+         $prof->displayRightsChoiceMatrix(
+            $rights
+         );
       }
 
-      $prof->displayRightsChoiceMatrix(
-         $rights
-      );
       echo "</td></tr>";
       echo "<input type='hidden' name='itemtype' value='".$itemtype."'>";
 


### PR DESCRIPTION
`Profile::displayRightsChoiceMatrix()` displays the matrix after filling it with values corresponding to loaded profile. As there is no function to display a matrix based on multiple profiles, I displayed one matrix per profile to fix this bug quickly.
Maybe it should be enhanced later.
![object-rights](https://user-images.githubusercontent.com/33253653/39998712-415d3dba-5787-11e8-938f-48a79eba1f6c.jpg)
