### PR TITLE
Fix duplicated search option key bug

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -760,6 +760,18 @@ class PluginGenericobjectObject extends CommonDBTM {
       $index_exceptions = ['name' => 1, 'id' => 2, 'comment' => 16, 'date_mod' => 19,
                            'entities_id' => 80, 'is_recursive' => 86, 'notepad' => 90,
                            'date_creation' => 121];
+
+      // Don't use indexes blacklisted by other item types in plugin DataInjection.
+      $plugin = new Plugin();
+      if ($plugin->isActivated("datainjection")
+         && class_exists('PluginDatainjectionCommonInjectionLib')) {
+         $blacklisted_indexes = PluginDatainjectionCommonInjectionLib::getBlacklistedOptions(
+            get_called_class() //A class that extends PluginGenericobjectObject
+         );
+      } else {
+         $blacklisted_indexes = [];
+      }
+
       $index   = 3;
 
       $options = [];
@@ -770,6 +782,9 @@ class PluginGenericobjectObject extends CommonDBTM {
       ];
 
       $table   = getTableForItemType(get_called_class());
+
+      // Prevent usage of reserved and blacklisted indexes
+      $taken_indexes = array_merge($index_exceptions, $blacklisted_indexes);
 
       foreach (PluginGenericobjectSingletonObjectField::getInstance(get_called_class())
          as $field => $values
@@ -787,14 +802,17 @@ class PluginGenericobjectObject extends CommonDBTM {
          $currentindex = $index;
          if (isset($index_exceptions[$field])) {
             $currentindex = $index_exceptions[$field];
-         } else if (in_array($currentindex, $index_exceptions)) {
-            //If this index is reserved, jump to next
-            $currentindex++;
+         } else {
+            //If this index is reserved, jump to next available one.
+            while (in_array($currentindex, $taken_indexes)) {
+               $currentindex++;
+            }
          }
 
          $option = [
             'id' => $currentindex,
          ];
+         $taken_indexes[] = $option['id'];
 
          $item = new $this->objecttype->fields['itemtype'];
 


### PR DESCRIPTION
Fix these error messages in log: CommonDBTM::searchOptions() in /opt/bitnami/apps/glpi/htdocs/inc/commondbtm.class.php line 3455
Duplicate key # (field A/field B) in PluginGenericobjectFoo searchOptions!

This also fixes the issue of missing fields in dropdowns for objects created with GenericObjects. For example, fields like serial where not in the list of fields to select when defining duplicity rules. It will probably fix some other issues too, because this affects anything that relies on SearchOptions, like dropdowns related to GenericObjects.

This fix can only ensure that the $options array stops repeating itself. The fix heavily relies on the provided $index_exceptions array to avoid globally reserved indexes.

The $options array repeated itself, because the "$currentindex = $index_exceptions[$field]" sometimes jumps to a lower index. The code "If this index is reserved, jump to next: $currentindex++;" was wrong in assuming that incrementing would always choose an unused index.