### PR TITLE
Handle numbers in object types; fixes #241

### DIFF
--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -996,29 +996,38 @@ class PluginGenericobjectType extends CommonDBTM {
    }
 
 
-   //Form pages
    static function getCompleteClassFilename($name) {
-      return GENERICOBJECT_CLASS_PATH . "/".$name.".class.php";
+      return GENERICOBJECT_CLASS_PATH . "/".self::getSystemName($name).".class.php";
+   }
+
+
+   static function getCompleteItemClassFilename($name) {
+      return GENERICOBJECT_CLASS_PATH . "/".self::getSystemName($name)."_item.class.php";
    }
 
 
    static function getCompleteFormFilename($name) {
-      return GENERICOBJECT_FRONT_PATH . "/".$name.".form.php";
+      return GENERICOBJECT_FRONT_PATH . "/".self::getSystemName($name).".form.php";
    }
 
 
    static function getCompleteSearchFilename($name) {
-      return GENERICOBJECT_FRONT_PATH . "/".$name.".php";
+      return GENERICOBJECT_FRONT_PATH . "/".self::getSystemName($name).".php";
    }
 
 
    static function getCompleteAjaxTabFilename($name) {
-      return GENERICOBJECT_AJAX_PATH . "/".$name.".tabs.php";
+      return GENERICOBJECT_AJAX_PATH . "/".self::getSystemName($name).".tabs.php";
    }
 
 
    static function getCompleteInjectionFilename($name) {
-      return GENERICOBJECT_CLASS_PATH . "/".$name."injection.class.php";
+      return GENERICOBJECT_CLASS_PATH . "/".self::getSystemName($name).".injection.class.php";
+   }
+
+
+   static function getCompleteConstantFilename($name) {
+      return GENERICOBJECT_FIELDS_PATH . "/".self::getSystemName($name).".constant.php";
    }
 
 
@@ -1059,16 +1068,19 @@ class PluginGenericobjectType extends CommonDBTM {
 
    public static function addLocales($name, $itemtype) {
       global $CFG_GLPI;
-      $locale_dir = GENERICOBJECT_LOCALES_PATH."/".$name;
+
+      $fsname = self::getSystemName($name);
+
+      $locale_dir = GENERICOBJECT_LOCALES_PATH."/".$fsname;
       if (!is_dir($locale_dir)) {
          @ mkdir($locale_dir, 0755, true);
       }
 
       $locale_files = [
-         $name . '.' . $_SESSION['glpilanguage'],
+         $fsname . '.' . $_SESSION['glpilanguage'],
       ];
       if ($CFG_GLPI['language'] != $_SESSION['glpilanguage']) {
-         $locale_files[] = $name . '.' . $CFG_GLPI['language'];
+         $locale_files[] = $fsname . '.' . $CFG_GLPI['language'];
       }
 
       foreach ($locale_files as $locale_file) {
@@ -1086,7 +1098,7 @@ class PluginGenericobjectType extends CommonDBTM {
 
 
    public static function deleteLocales($name, $itemtype) {
-      $locale_dir = GENERICOBJECT_LOCALES_PATH."/".$name;
+      $locale_dir = GENERICOBJECT_LOCALES_PATH."/".self::getSystemName($name);
       if (file_exists($locale_dir)) {
          foreach (glob($locale_dir.'/*.php') as $file) {
             @unlink($file);
@@ -1120,26 +1132,28 @@ class PluginGenericobjectType extends CommonDBTM {
       self::addFileFromTemplate(['CLASSNAME' => self::getClassByName($name),
                                  'INJECTIONCLASS' => self::getClassByName($name)."Injection"],
                                 self::OBJECTINJECTION_TEMPLATE, GENERICOBJECT_CLASS_PATH,
-                                $name."injection.class");
+                                self::getSystemName($name)."injection.class");
    }
 
 
    public static function addDropdownFrontFile($name) {
       self::addFileFromTemplate(['CLASSNAME' => self::getClassByName($name)],
-                                self::FRONT_DROPDOWN_TEMPLATE, GENERICOBJECT_FRONT_PATH, $name);
+                                self::FRONT_DROPDOWN_TEMPLATE, GENERICOBJECT_FRONT_PATH,
+                                self::getSystemName($name));
    }
 
 
    public static function addAjaxFile($name, $field) {
       self::addFileFromTemplate(['CLASSNAME' => self::getClassByName($name)],
-                                self::AJAX_TEMPLATE, GENERICOBJECT_AJAX_PATH, $name.".tabs");
+                                self::AJAX_TEMPLATE, GENERICOBJECT_AJAX_PATH,
+                                self::getSystemName($name).".tabs");
    }
 
 
    public static function addDropdownFrontformFile($name) {
       self::addFileFromTemplate(['CLASSNAME' => self::getClassByName($name)],
                                 self::FRONTFORM_DROPDOWN_TEMPLATE, GENERICOBJECT_FRONT_PATH,
-                                $name.".form");
+                                self::getSystemName($name).".form");
    }
 
 
@@ -1156,7 +1170,7 @@ class PluginGenericobjectType extends CommonDBTM {
             'PluginGenericobject' . ($params['is_tree']?'CommonTree':'Common') . 'Dropdown',
          'FIELDNAME'       => $params['realname'],
          'LINKED_ITEMTYPE' => $params['linked_itemtype']
-      ], self::CLASS_DROPDOWN_TEMPLATE, GENERICOBJECT_CLASS_PATH, $name.".class");
+      ], self::CLASS_DROPDOWN_TEMPLATE, GENERICOBJECT_CLASS_PATH, self::getSystemName($name).".class");
    }
 
 
@@ -1169,7 +1183,8 @@ class PluginGenericobjectType extends CommonDBTM {
     */
    public static function addClassFile($name, $classname) {
       self::addFileFromTemplate(['CLASSNAME' => self::getClassByName($name)],
-                                self::CLASS_TEMPLATE, GENERICOBJECT_CLASS_PATH, $name.".class");
+                                self::CLASS_TEMPLATE, GENERICOBJECT_CLASS_PATH,
+                                self::getSystemName($name).".class");
    }
 
    /**
@@ -1184,7 +1199,8 @@ class PluginGenericobjectType extends CommonDBTM {
       self::addFileFromTemplate(['CLASSNAME'    => $class,
                                  'FOREIGNKEY'   => getForeignKeyFieldForItemType($classname),
                                  'SOURCEOBJECT' => $classname],
-            self::OBJECTITEM_TEMPLATE, GENERICOBJECT_CLASS_PATH, $name."_item.class");
+            self::OBJECTITEM_TEMPLATE, GENERICOBJECT_CLASS_PATH,
+                                self::getSystemName($name)."_item.class");
    }
 
    /**
@@ -1196,7 +1212,8 @@ class PluginGenericobjectType extends CommonDBTM {
     */
    public static function addFormFile($name, $classname) {
       self::addFileFromTemplate(['CLASSNAME' => self::getClassByName($name)],
-                                self::FORM_TEMPLATE, GENERICOBJECT_FRONT_PATH, $name.".form");
+                                self::FORM_TEMPLATE, GENERICOBJECT_FRONT_PATH,
+                                self::getSystemName($name).".form");
    }
 
 
@@ -1209,7 +1226,8 @@ class PluginGenericobjectType extends CommonDBTM {
     */
    public static function addSearchFile($name, $classname) {
       self::addFileFromTemplate(['CLASSNAME' => self::getClassByName($name)],
-                                self::SEARCH_TEMPLATE, GENERICOBJECT_FRONT_PATH, $name);
+                                self::SEARCH_TEMPLATE, GENERICOBJECT_FRONT_PATH,
+                                self::getSystemName($name));
    }
 
 
@@ -1224,21 +1242,22 @@ class PluginGenericobjectType extends CommonDBTM {
       global $DB;
 
       foreach (self::getTypes(true) as $type) {
-         //ensure old files has been removed
-         if (file_exists(GENERICOBJECT_DIR . "/inc/{$type['name']}.class.php")) {
-            unlink(GENERICOBJECT_CLASS_PATH . "/inc/{$type['name']}.class.php");
+         //ensure old files has been removed,
+         $fsname = self::getSystemName($type['name']);
+         if (file_exists(GENERICOBJECT_DIR . "/inc/{$fsname}.class.php")) {
+            unlink(GENERICOBJECT_DIR . "/inc/{$fsname}.class.php");
          }
-         if (file_exists(GENERICOBJECT_DIR . "/front/{$type['name']}.form.php")) {
-            unlink(GENERICOBJECT_DIR . "/front/{$type['name']}.form.php");
+         if (file_exists(GENERICOBJECT_DIR . "/front/{$fsname}.form.php")) {
+            unlink(GENERICOBJECT_DIR . "/front/{$fsname}.form.php");
          }
-         if (file_exists(GENERICOBJECT_DIR . "/front/{$type['name']}.php")) {
-            unlink(GENERICOBJECT_DIR . "/front/{$type['name']}.form.php");
+         if (file_exists(GENERICOBJECT_DIR . "/front/{$fsname}.php")) {
+            unlink(GENERICOBJECT_DIR . "/front/{$fsname}.form.php");
          }
-         if (file_exists(GENERICOBJECT_DIR . "/ajax/{$type['name']}.tabs.php")) {
-            unlink(GENERICOBJECT_DIR . "/ajax/{$type['name']}.tabs.php");
+         if (file_exists(GENERICOBJECT_DIR . "/ajax/{$fsname}.tabs.php")) {
+            unlink(GENERICOBJECT_DIR . "/ajax/{$fsname}.tabs.php");
          }
-         if (file_exists(GENERICOBJECT_DIR . "/inc/{$type['name']}.injection.class.php")) {
-            unlink(GENERICOBJECT_DIR . "/inc/{$type['name']}.injection.class.php");
+         if (file_exists(GENERICOBJECT_DIR . "/inc/{$fsname}.injection.class.php")) {
+            unlink(GENERICOBJECT_DIR . "/inc/{$fsname}.injection.class.php");
          }
 
          self::checkClassAndFilesForOneItemType($type['itemtype'], $type['name'], true, false);
@@ -1281,7 +1300,7 @@ class PluginGenericobjectType extends CommonDBTM {
                ) {
                   $params['linked_itemtype'] = $itemtype;
                }
-               self::addNewDropdown($name, 'PluginGenericobject'.ucfirst($name), $params);
+               self::addNewDropdown($name, self::getClassByName($name), $params);
             }
          }
       }
@@ -1598,12 +1617,31 @@ class PluginGenericobjectType extends CommonDBTM {
 
 
    /**
+    * Get the object system name (for files and itemtype), by giving the name
+    *
+    * @param string $name
+    *
+    * @return string
+    */
+   static function getSystemName($name) {
+      // Force filtering of name (will have no effect if already done).
+      $name = self::filterInput($name);
+
+      // Replace numbers by letters
+      return str_replace(
+         ['0',    '1',   '2',   '3',     '4',    '5',    '6',   '7',     '8',     '9'],
+         ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'],
+         $name
+      );
+   }
+
+   /**
     * Get the object class, by giving the name
     * @param name the object's internal identifier
     * @return the class associated with the object
     */
    static function getClassByName($name) {
-      return 'PluginGenericobject' . ucfirst($name);
+      return 'PluginGenericobject' . ucfirst(self::getSystemName($name));
    }
 
 
@@ -1620,29 +1658,6 @@ class PluginGenericobjectType extends CommonDBTM {
             return $family->getName();
          } else {
             return false;
-         }
-      }
-   }
-
-   /**
-    * Ensure names are singular at upgrade
-    *
-    * @return void
-    */
-   static function singularTypes() {
-      global $DB;
-      $table = getTableForItemType(__CLASS__);
-      if ($DB->tableExists($table)) {
-         $query = "SELECT id, name, itemtype FROM $table";
-         foreach ($DB->query($query) as $data) {
-            $singularname = self::filterInput($data['name']);
-            $singulartype = getSingular($data['itemtype']);
-            if ($data['name'] != $singularname || $data['itemtype'] != $singulartype) {
-               //do not use objects here to prevent pre/post issues
-               $update = "UPDATE $table SET name='$singularname', itemtype='$singulartype' WHERE id={$data['id']}";
-               $DB->query($update);
-               self::deleteFilesAndClassesForOneItemtype($data['name']);
-            }
          }
       }
    }
@@ -1676,7 +1691,7 @@ class PluginGenericobjectType extends CommonDBTM {
          $mytypes = [];
          foreach (getAllDatasFromTable($table, (!$all ? ['is_active' => self::ACTIVE] : [])) as $data) {
             //If class is not present on the filesystem, do not list itemtype
-            if (file_exists(GENERICOBJECT_CLASS_PATH."/".$data['name'].".class.php")) {
+            if (file_exists(self::getCompleteClassFilename($data['name']))) {
                $mytypes[$data['plugin_genericobject_typefamilies_id']][$data['itemtype']] = $data;
             }
          }
@@ -1707,7 +1722,9 @@ class PluginGenericobjectType extends CommonDBTM {
    static function includeLocales($name) {
       global $CFG_GLPI,$LANG;
 
-      $prefix = GENERICOBJECT_LOCALES_PATH . "/$name/$name";
+      $fsname = self::getSystemName($name);
+
+      $prefix = GENERICOBJECT_LOCALES_PATH . "/$fsname/$fsname";
         //Dirty hack because the plugin doesn't support gettext...
       $language= str_replace('.mo', '', $CFG_GLPI["languages"][$_SESSION["glpilanguage"]][1]);
       if (isset ($_SESSION["glpilanguage"])
@@ -1730,7 +1747,8 @@ class PluginGenericobjectType extends CommonDBTM {
 
 
    static function includeConstants($name, $force = false) {
-      $file = GENERICOBJECT_FIELDS_PATH . "/$name.constant.php";
+
+      $file = self::getCompleteConstantFilename($name);
       if (file_exists($file)) {
          if (!$force) {
             include_once($file);
@@ -2025,6 +2043,9 @@ class PluginGenericobjectType extends CommonDBTM {
       $migration->addField($table, "use_plugin_treeview", "bool");
       $migration->migrationOneTable($table);
 
+      //Normalize names and itemtypes (prior to using them).
+      self::normalizeNamesAndItemtypes($migration);
+
       //If files are missing, recreate them!
       self::checkClassAndFilesForItemType();
 
@@ -2081,8 +2102,6 @@ class PluginGenericobjectType extends CommonDBTM {
             $preference->add($tmp);
          }
       }
-
-      self::singularTypes();
    }
 
 
@@ -2102,5 +2121,248 @@ class PluginGenericobjectType extends CommonDBTM {
       //Delete table
       $query = "DROP TABLE IF EXISTS `glpi_plugin_genericobject_types`";
       $DB->query($query) or die($DB->error());
+   }
+
+   /**
+    * Normalize itemtype and name for all types.
+    * This method will ensure that new normalization rules will be taken into account
+    * during migration from an old version without loosing existing data.
+    *
+    * @param Migration $migration
+    * @return void
+    */
+   private static function normalizeNamesAndItemtypes(Migration $migration) {
+      global $DB;
+      $DB->disableTableCaching();
+
+      $types_iterator = $DB->request(
+         [
+            'FROM'  => self::getTable(),
+            'ORDER' => 'name',
+         ]
+      );
+
+      foreach ($types_iterator as $type) {
+         $old_name     = $type['name'];
+         $new_name     = self::filterInput($old_name);
+         $old_itemtype = $type['itemtype'];
+         $new_itemtype = self::getClassByName($new_name);
+
+         if ($old_name == $new_name && $old_itemtype == $new_itemtype) {
+            continue;
+         }
+
+         self::updateNameAndItemtype(
+            $migration,
+            $old_name,
+            $new_name,
+            $old_itemtype,
+            $new_itemtype
+         );
+
+         $DB->update(
+            self::getTable(),
+            [
+               'name'     => $new_name,
+               'itemtype' => $new_itemtype,
+            ],
+            ['id' => $type['id']]
+         );
+
+         $DB->update(
+            self::getTable(),
+            [
+               'linked_itemtypes' => new \QueryExpression(
+                  'REPLACE('
+                  . $DB->quoteName('linked_itemtypes')
+                  . ','
+                  . $DB->quoteValue('"' . $old_itemtype .'"') // itemtype is surrounded by quotes
+                  . ','
+                  . $DB->quoteValue('"' . $new_itemtype .'"') // itemtype is surrounded by quotes
+                  . ')'
+               ),
+            ],
+            ['linked_itemtypes' => ['LIKE', '%"' . $old_itemtype . '"%']]
+         );
+
+         // Handle dropdowns related to itemtype
+         $table  = getTableForItemType($new_itemtype);
+         $fields = $DB->list_fields($table);
+         foreach ($fields as $field => $options) {
+            if (preg_match("/s_id$/", $field)) {
+               $dropdown_old_table    = getTableNameForForeignKeyField($field);
+
+               if (!preg_match('/^glpi_plugin_genericobject_/', $dropdown_old_table)) {
+                  continue;
+               }
+
+               $dropdown_old_name     = getSingular(
+                  str_replace(
+                     "glpi_plugin_genericobject_",
+                     "",
+                     $dropdown_old_table
+                  )
+               );
+               $dropdown_old_itemtype = 'PluginGenericobject' . ucfirst($dropdown_old_name);
+               $dropdown_new_name     = self::filterInput($dropdown_old_name);
+               $dropdown_new_itemtype = self::getClassByName($dropdown_new_name);
+
+               if ($dropdown_old_name == $dropdown_new_name
+                   && $dropdown_old_itemtype == $dropdown_new_itemtype) {
+                  continue;
+               }
+
+               self::updateNameAndItemtype(
+                  $migration,
+                  $dropdown_old_name,
+                  $dropdown_new_name,
+                  $dropdown_old_itemtype,
+                  $dropdown_new_itemtype
+               );
+            }
+         }
+      }
+
+      ProfileRight::cleanAllPossibleRights(); // Clean all possible rights are their name may have change
+   }
+
+   /**
+    * Update itemtype and/or name for a given itemtype.
+    *
+    * @param Migration $migration
+    * @param string    $old_name      Current type name in database
+    * @param string    $new_name      New type name to use
+    * @param string    $old_itemtype  Current itemtype
+    * @param string    $new_itemtype  New itemtype to use
+    *
+    * @return void
+    */
+   private static function updateNameAndItemtype(Migration $migration, $old_name, $new_name,
+                                                 $old_itemtype, $new_itemtype) {
+
+      global $DB;
+
+      if ($old_itemtype != $new_itemtype) {
+         $migration->renameItemtype($old_itemtype, $new_itemtype);
+         $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
+      }
+
+      $destination_files = [];
+
+      $old_systemname = $old_name; // Old system name was same as name in DB
+      $new_systemname = self::getSystemName($new_name);
+      $old_fkey       = getForeignKeyFieldForItemType($old_itemtype);
+      $new_fkey       = getForeignKeyFieldForItemType($new_itemtype);
+      $old_locale_dir = GENERICOBJECT_LOCALES_PATH . '/' . $old_systemname;
+      $new_locale_dir = GENERICOBJECT_LOCALES_PATH . '/' . $new_systemname;
+
+      $destination_files = [
+         self::getCompleteClassFilename($new_name),
+         self::getCompleteItemClassFilename($new_name),
+         self::getCompleteFormFilename($new_name),
+         self::getCompleteSearchFilename($new_name),
+         self::getCompleteAjaxTabFilename($new_name),
+         self::getCompleteInjectionFilename($new_name),
+         self::getCompleteConstantFilename($new_name),
+      ];
+
+      // Rename locale folder and map files
+      if (is_dir($old_locale_dir) && $old_locale_dir != $new_locale_dir) {
+         if (rename($old_locale_dir, $new_locale_dir)) {
+            // Add all locale files to destination files
+            foreach (glob($new_locale_dir . '/*.php') as $old_filename) {
+               $destination_files[] = preg_replace(
+                  '/(.*\/)' . preg_quote($old_systemname, '/') . '([^\/]*)$/',
+                  '$1' . $new_systemname . '$2',
+                  $old_filename
+               );
+            }
+         } else {
+            $migration->displayWarning(
+               sprintf('Unable to rename "%s" locale directory to "%s"', $old_locale_dir, $new_locale_dir),
+               true
+            );
+         }
+      }
+
+      // Handle *_item class table/itemtype
+      if ($DB->tableExists(getTableForItemType($old_itemtype . '_Item'))) {
+         $migration->renameItemtype($old_itemtype . '_Item', $new_itemtype . '_Item');
+         $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
+      }
+
+      // Add all constant files as they may contains foreign keys to update
+      foreach (glob(GENERICOBJECT_FIELDS_PATH . '/*.php') as $constant_filename) {
+         $destination_files[] = $constant_filename;
+      }
+
+      // Rename files (replace "/{$old name}*" by "/{$new_system_name}*")
+      $migration->displayMessage(
+         sprintf('Rename files related to "%s" itemtype and update their content', $old_itemtype),
+         true
+      );
+      foreach ($destination_files as $new_filename) {
+         $old_filename = preg_replace(
+            '/(.*\/)' . preg_quote($new_systemname, '/') . '([^\/]*)$/',
+            '$1' . $old_systemname . '$2',
+            $new_filename
+         );
+
+         if (!file_exists($old_filename)) {
+            // Do nothing if old file does not exists
+            continue;
+         }
+
+         if ($old_filename != $new_filename) {
+            if (!rename($old_filename, $new_filename)) {
+               $migration->displayWarning(
+                  sprintf('Unable to rename "%s" file to "%s"', $old_filename, $new_filename),
+                  true
+               );
+               continue;
+            }
+         } else {
+            $migration->displayMessage(
+               sprintf('Update "%s" file content', $old_filename),
+               true
+            );
+         }
+
+         $file_contents = file_get_contents($new_filename);
+         if (!$file_contents) {
+            $migration->displayWarning(
+               sprintf('Unable to read "%s" file contents', $new_filename),
+               true
+            );
+            continue;
+         }
+
+         $replace_count = 0;
+         $old_fkey_truncated = preg_replace('/^plugin_genericobject_/', '', $old_fkey);
+         $new_fkey_truncated = preg_replace('/^plugin_genericobject_/', '', $new_fkey);
+         $file_contents = str_replace(
+            [$old_itemtype, $old_fkey, $old_fkey_truncated],
+            [$new_itemtype, $new_fkey, $new_fkey_truncated],
+            $file_contents,
+            $replace_count
+         );
+         if ($replace_count > 0 && !file_put_contents($new_filename, $file_contents)) {
+            $migration->displayWarning(
+               sprintf('Unable to update "%s" file contents', $new_filename),
+               true
+            );
+         }
+      }
+
+      // Update profile rights
+      if ($old_itemtype != $new_itemtype) {
+         $migration->addPostQuery(
+            $DB->buildUpdate(
+               ProfileRight::getTable(),
+               ['name' => PluginGenericobjectProfile::getProfileNameForItemtype($new_itemtype)],
+               ['name' => PluginGenericobjectProfile::getProfileNameForItemtype($old_itemtype)]
+            )
+         );
+      }
    }
 }

--- a/setup.php
+++ b/setup.php
@@ -38,9 +38,9 @@
 define ('PLUGIN_GENERICOBJECT_VERSION', '2.8.0');
 
 // Minimal GLPI version, inclusive
-define("PLUGIN_GENERICOBJECT_MIN_GLPI", "9.4");
+define("PLUGIN_GENERICOBJECT_MIN_GLPI", "9.5");
 // Maximum GLPI version, exclusive
-define("PLUGIN_GENERICOBJECT_MAX_GLPI", "9.5");
+define("PLUGIN_GENERICOBJECT_MAX_GLPI", "9.6");
 
 if (!defined("GENERICOBJECT_DIR")) {
    define("GENERICOBJECT_DIR", GLPI_ROOT . "/plugins/genericobject");


### PR DESCRIPTION
From GLPI 9.4.x, generic objects containing numeric chars are handled correctly in search view.

Problem is the same as in "fields" plugin (see https://github.com/pluginsGLPI/fields/pull/306).