### PR TITLE
fix(core): fix duplicate result for global search

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -214,11 +214,12 @@ class PluginGenericobjectObject extends CommonDBTM {
             if (!in_array($class, $CFG_GLPI['asset_types'])) {
                array_push($CFG_GLPI['asset_types'], $class);
             }
-            if (!in_array($class, $CFG_GLPI['globalsearch_types'])) {
-               array_push($CFG_GLPI['globalsearch_types'], $class);
-            }
+
             if (!in_array($class, $CFG_GLPI['state_types'])) {
                array_push($CFG_GLPI['state_types'], $class);
+            }
+
+            if (!in_array($class, $CFG_GLPI['globalsearch_types'])) {
                array_push($CFG_GLPI['globalsearch_types'], $class);
             }
          }


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

global search display to result for genericobject

![image](https://user-images.githubusercontent.com/7335054/73063624-8167b100-3e9f-11ea-8828-73114fe7c59f.png)


this PR prevent duplicate result on global search
