### PR TITLE
Horizontal separator

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -360,6 +360,7 @@ class PluginGenericobjectField extends CommonDBTM {
             case 'bool' :
                $query .= "TINYINT (1) NOT NULL DEFAULT '0'";
                break;
+            case 'horizontalseparator' :
             case 'emptyspace' :
             case 'text' :
                $query .= "VARCHAR ( 255 ) collate utf8_unicode_ci NOT NULL DEFAULT ''";

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -582,6 +582,11 @@ class PluginGenericobjectObject extends CommonDBTM {
             $description['Type'] = 'emptyspace';
          }
 
+         if (isset($searchoption['input_type']) && 'horizontalseparator' === $searchoption['input_type']) {
+            $this->DisplayHorizontalSeparator($searchoption['name']);
+            return;
+         }
+
          $this->startColumn();
          echo $searchoption['name'];
          if (isset($searchoption['autoname']) && $searchoption['autoname'] && $template) {
@@ -741,6 +746,15 @@ class PluginGenericobjectObject extends CommonDBTM {
       }
    }
 
+   /**
+   * Display an horizontal separator on all columns
+   **/
+
+   function DisplayHorizontalSeparator($name) {
+      $this->closeColumn();
+      echo '<tr class="tab_bg_1"><th colspan="4">'. $name."</th></tr>";
+      $this->cpt = 0;
+   }
 
    function prepareInputForAdd($input) {
 


### PR DESCRIPTION
allow the capacity to create a visual horizontal separation between fields

sample to add in /fields/*.constant.php

$GO_FIELDS['hrnewsection']['name']       = 'NEW VISUAL SECTION';
$GO_FIELDS['hrnewsection']['input_type'] = 'horizontalseparator';
