### PR TITLE
Fix rightname when object name ends with two "s"

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -64,6 +64,8 @@ class PluginGenericobjectObject extends CommonDBTM {
       if (preg_match("/PluginGenericobject(.*)/", $class, $results)) {
          if (preg_match("/^(.*)y$/i", $results[1], $end_results)) {
             static::$rightname = 'plugin_genericobject_'.strtolower($end_results[1]).'ies';
+         } elseif (preg_match("/^(.*)ss$/i", $results[1])) {
+            static::$rightname = 'plugin_genericobject_'.strtolower($results[1]).'es';
          } else {
             static::$rightname = 'plugin_genericobject_'.strtolower($results[1]).'s';
          }

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -64,7 +64,7 @@ class PluginGenericobjectObject extends CommonDBTM {
       if (preg_match("/PluginGenericobject(.*)/", $class, $results)) {
          if (preg_match("/^(.*)y$/i", $results[1], $end_results)) {
             static::$rightname = 'plugin_genericobject_'.strtolower($end_results[1]).'ies';
-         } elseif (preg_match("/^(.*)ss$/i", $results[1])) {
+         } else if (preg_match("/^(.*)ss$/i", $results[1])) {
             static::$rightname = 'plugin_genericobject_'.strtolower($results[1]).'es';
          } else {
             static::$rightname = 'plugin_genericobject_'.strtolower($results[1]).'s';


### PR DESCRIPTION
#244 
When you add a name with double s (glass), GLPI cannot correctly check the object's permissions.
Genericobject declares the rightname with sss (plugin_genericobject_glasss) but GLPI searches for ses (plugin_genericobject_glasses).
This causes some tabs not to load correctly, such as Notepad