### PR TITLE
Fix undefined index

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -228,9 +228,9 @@ class PluginGenericobjectObject extends CommonDBTM {
                array_push($CFG_GLPI['asset_types'], $class);
             }
 
-            if (!in_array($class, $CFG_GLPI['state_types'])) {
+            /*if (!in_array($class, $CFG_GLPI['state_types'])) {
                array_push($CFG_GLPI['state_types'], $class);
-            }
+            }*/
 
             if (!in_array($class, $CFG_GLPI['globalsearch_types'])) {
                array_push($CFG_GLPI['globalsearch_types'], $class);


### PR DESCRIPTION
If when creating an object (Vehicle) you select the option "Use Global search".
When accessing the status dropdown it will generate the error PHP Notice (8): Undefined index: is_visible_plugingenericobjectvehicle in /usr/share/glpi/inc/commondropdown.class.php at line 395
![imagen](https://user-images.githubusercontent.com/39123808/97855100-96108980-1cfa-11eb-9b62-f9ed211b011d.png)
