### PR TITLE
Add support for impact analysis

### DIFF
--- a/front/getimpacticon.php
+++ b/front/getimpacticon.php
@@ -53,6 +53,12 @@ if ($filepath === null) {
     die;
 }
 
+// Validate image
+if (!Document::isImage($filepath)) {
+    http_response_code(400);
+    die;
+}
+
 // Send image
 header("Content-Type: " . mime_content_type($filepath));
 readfile($filepath);

--- a/front/getimpacticon.php
+++ b/front/getimpacticon.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * GenericObject plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GenericObject.
+ *
+ * GenericObject is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GenericObject is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GenericObject. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2009-2022 by GenericObject plugin team.
+ * @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/pluginsGLPI/genericobject
+ * -------------------------------------------------------------------------
+ */
+
+include ("../../../inc/includes.php");
+
+// Read itemtype
+$itemtype = $_GET['itemtype'] ?? null;
+
+// Missing required parameter
+if (empty($itemtype)) {
+    http_response_code(400);
+    die;
+}
+
+// Find by itemtype
+$type = new PluginGenericobjectType();
+if (!$type->getFromDBByCrit(['itemtype' => $itemtype])) {
+    http_response_code(400);
+    die;
+}
+
+// Get filepath
+$filepath = $type->getImpactIconFilePath();
+if ($filepath === null) {
+    http_response_code(404);
+    die;
+}
+
+// Send image
+header("Content-Type: " . mime_content_type($filepath));
+readfile($filepath);
+die;

--- a/hook.php
+++ b/hook.php
@@ -114,6 +114,12 @@ function plugin_genericobject_install() {
          or die("Can't create folder " . GENERICOBJECT_CLASS_PATH);
    }
 
+   // Add icon directory
+   $icons_dir = GLPI_PLUGIN_DOC_DIR . '/genericobject/impact_icons/';
+   if (!is_dir($icons_dir)) {
+      mkdir($icons_dir);
+   }
+
    //Init plugin & types
    plugin_init_genericobject();
 

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -367,6 +367,11 @@ class PluginGenericobjectObject extends CommonDBTM {
 
       if (!$this->isNewItem()) {
 
+         // Register impact tab is enabled
+         if ($this->canUseImpact()) {
+            $this->addImpactTab($tabs, $options);
+         }
+
          if ($this->canUseNetworkPorts()) {
             $this->addStandardTab('NetworkPort', $tabs, $options);
          }
@@ -515,6 +520,10 @@ class PluginGenericobjectObject extends CommonDBTM {
 
    function canUseItemDevice() {
       return ($this->objecttype->canUseItemDevice());
+   }
+
+   function canUseImpact() {
+      return ($this->objecttype->canUseImpact());
    }
 
    function title() {

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -201,8 +201,8 @@ class PluginGenericobjectType extends CommonDBTM {
 
    function prepareInputForUpdate($input) {
       // Handle impact icon uploads
-      $icon = $input['_impact_icon'][0] ?? null;
-      if ($icon) {
+      $icon = isset($input['_impact_icon'][0]) ? realpath($input['_impact_icon'][0])) : false;
+      if ($icon !== false && str_starts_with($icon, realpath(GLPI_TMP_DIR))) {
          rename(
             GLPI_TMP_DIR . "/$icon",
             self::getImpactIconFileStoragePath($icon)
@@ -229,7 +229,7 @@ class PluginGenericobjectType extends CommonDBTM {
          return $input;
       }
 
-      // Impact analysis was enabled, update conf if needed
+      // Impact analysis will now be enabled, update conf if needed
       if ($use_impact && !Impact::isEnabled($this->fields['itemtype'])) {
          $enabled = Config::getConfigurationValue('core', Impact::CONF_ENABLED);
          $enabled = importArrayFromDB($enabled);
@@ -240,7 +240,7 @@ class PluginGenericobjectType extends CommonDBTM {
          return $input;
       }
 
-      // Impact analysis was disabled, update config if needed
+      // Impact analysis will now be disabled, update config if needed
       if (!$use_impact && Impact::isEnabled($this->fields['itemtype'])) {
          $enabled = Config::getConfigurationValue('core', Impact::CONF_ENABLED);
          $enabled = importArrayFromDB($enabled);

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -230,6 +230,11 @@ class PluginGenericobjectType extends CommonDBTM {
          return $input;
       }
 
+      // Wrong file type, ignore
+      if (!Document::isImage($icon_path)) {
+         return $input;
+      }
+
       // File is outside of GLPI_TMP_DIR
       if (!str_starts_with($icon_path, realpath(GLPI_TMP_DIR))) {
          trigger_error("Trying to read forbidden file: $icon_path", E_USER_WARNING);

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -239,17 +239,20 @@ class PluginGenericobjectType extends CommonDBTM {
       // Reread base file name
       $icon_filename = pathinfo($icon_path, PATHINFO_BASENAME);
 
-      // Remove previous icon if exist - WIP
-      // $existing_icon_path = self::getImpactIconFileStoragePath(
-      //    $this->fields['impact_icon'],
-      //    $this->fields['itemtype']
-      // );
-      // if ($existing_icon_path
-      //    && file_exists($existing_icon_path)
-      //    && str_starts_with(realpath($existing_icon_path), realpath(Plugin))
-      // ) {
-      //    unlink($existing_icon_path);
-      // }
+      // Remove previous icon if exist
+      $existing_icon_path = self::getImpactIconFileStoragePath(
+         $this->fields['impact_icon'],
+         $this->fields['itemtype']
+      );
+      if ($existing_icon_path
+         && file_exists($existing_icon_path)
+         && str_starts_with(
+            realpath($existing_icon_path),
+            realpath(GLPI_PLUGIN_DOC_DIR . "/genericobject/impact_icons/")
+         )
+      ) {
+         unlink($existing_icon_path);
+      }
 
       // Move file and update input on success
       $new_path = self::getImpactIconFileStoragePath(

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -260,6 +260,12 @@ class PluginGenericobjectType extends CommonDBTM {
       }
 
       // Move file and update input on success
+      $icons_dir = GLPI_PLUGIN_DOC_DIR . '/genericobject/impact_icons/';
+      if (!is_dir($icons_dir) && !mkdir($icons_dir)) {
+         trigger_error(sprintf('Unable to create "%s" directory.', $icons_dir), E_USER_WARNING);
+         return $input;
+      }
+
       $new_path = self::getImpactIconFileStoragePath(
          $icon_filename,
          $this->fields['itemtype']

--- a/setup.php
+++ b/setup.php
@@ -192,24 +192,13 @@ function plugin_init_genericobject() {
          mkdir(GLPI_PLUGIN_DOC_DIR . "/genericobject/impact_icons/");
       }
 
-      // Enable impact analysis
-      foreach (
-         (new PluginGenericobjectType())->find([
-            'use_impact' => true,
-         ]) as $row
-      ) {
+      // Add every genericobject item's to the list of itemtypes for which the
+      // impact analysis can be enabled
+      foreach ((new PluginGenericobjectType())->find([]) as $row) {
          $CFG_GLPI['impact_asset_types'][$row['itemtype']] = PluginGenericobjectType::getImpactIconFileStoragePath(
             $row['impact_icon'],
             true
          );
-
-         // Update DB conf
-         $enabled = Config::getConfigurationValue('core', Impact::CONF_ENABLED);
-         $enabled = importArrayFromDB($enabled);
-         $enabled[] = $row['itemtype'];
-         Config::setConfigurationValues('core', [
-            Impact::CONF_ENABLED => exportArrayToDB($enabled)
-         ]);
       }
    }
 }

--- a/setup.php
+++ b/setup.php
@@ -187,11 +187,6 @@ function plugin_init_genericobject() {
          'getTypesForFormcreator'
       ];
 
-      // Add icon folder
-      if (!file_exists(GLPI_PLUGIN_DOC_DIR . "/genericobject/impact_icons/")) {
-         mkdir(GLPI_PLUGIN_DOC_DIR . "/genericobject/impact_icons/");
-      }
-
       // Add every genericobject item's to the list of itemtypes for which the
       // impact analysis can be enabled
       foreach ((new PluginGenericobjectType())->find([]) as $row) {

--- a/setup.php
+++ b/setup.php
@@ -106,7 +106,7 @@ $go_autoloader->register();
  */
 function plugin_init_genericobject() {
    global $PLUGIN_HOOKS, $GO_BLACKLIST_FIELDS,
-          $GENERICOBJECT_PDF_TYPES, $GO_LINKED_TYPES, $GO_READONLY_FIELDS;
+          $GENERICOBJECT_PDF_TYPES, $GO_LINKED_TYPES, $GO_READONLY_FIELDS, $CFG_GLPI;
 
    $GO_READONLY_FIELDS  =  ["is_helpdesk_visible", "comment"];
 
@@ -186,6 +186,31 @@ function plugin_init_genericobject() {
          PluginGenericobjectType::getType(),
          'getTypesForFormcreator'
       ];
+
+      // Add icon folder
+      if (!file_exists(GLPI_PLUGIN_DOC_DIR . "/genericobject/impact_icons/")) {
+         mkdir(GLPI_PLUGIN_DOC_DIR . "/genericobject/impact_icons/");
+      }
+
+      // Enable impact analysis
+      foreach (
+         (new PluginGenericobjectType())->find([
+            'use_impact' => true,
+         ]) as $row
+      ) {
+         $CFG_GLPI['impact_asset_types'][$row['itemtype']] = PluginGenericobjectType::getImpactIconFileStoragePath(
+            $row['impact_icon'],
+            true
+         );
+
+         // Update DB conf
+         $enabled = Config::getConfigurationValue('core', Impact::CONF_ENABLED);
+         $enabled = importArrayFromDB($enabled);
+         $enabled[] = $row['itemtype'];
+         Config::setConfigurationValues('core', [
+            Impact::CONF_ENABLED => exportArrayToDB($enabled)
+         ]);
+      }
    }
 }
 

--- a/setup.php
+++ b/setup.php
@@ -195,10 +195,17 @@ function plugin_init_genericobject() {
       // Add every genericobject item's to the list of itemtypes for which the
       // impact analysis can be enabled
       foreach ((new PluginGenericobjectType())->find([]) as $row) {
-         $CFG_GLPI['impact_asset_types'][$row['itemtype']] = PluginGenericobjectType::getImpactIconFileStoragePath(
-            $row['impact_icon'],
-            true
-         );
+         if (empty($row['impact_icon'])) {
+            $icon = ""; // Will fallback to default impact icon
+         } else {
+            $icon = PluginGenericobjectType::getImpactIconFileStoragePath(
+               $row['impact_icon'],
+               $row['itemtype'],
+               true
+            ) ?? "";
+         }
+
+         $CFG_GLPI['impact_asset_types'][$row['itemtype']] = $icon;
       }
    }
 }


### PR DESCRIPTION
Two new configuration options were added to:
- Enable impact analysis for the given type
- Upload a custom icon to be used in the impact analysis

![image](https://user-images.githubusercontent.com/42734840/182559271-330600f3-d814-4c8a-af89-3d7a300b2d2b.png)

Working example:

![image](https://user-images.githubusercontent.com/42734840/182559815-d5a8c58f-1e20-43a7-b6c0-4aa98d503390.png)


