### PR TITLE
Add section and colspan on formulary

### DIFF
--- a/fields/field.constant.php
+++ b/fields/field.constant.php
@@ -51,7 +51,7 @@ $GO_FIELDS['otherserial']['autoname']   = true;
 $GO_FIELDS['comment']['name']       = __("Comments");
 $GO_FIELDS['comment']['field']      = 'comment';
 $GO_FIELDS['comment']['input_type'] = 'multitext';
-$GO_FIELDS['gestion']['colums']     = '3'; //[CRI] : colums - Add colspan on formulary			 			   
+$GO_FIELDS['comment']['colums']     = '3'; //[CRI] : colums - Add colspan on formulary			 			   
 
 $GO_FIELDS['other']['name']         = __("Others");
 $GO_FIELDS['other']['input_type']   = 'text';
@@ -76,8 +76,6 @@ $GO_FIELDS['url']['datatype']   = 'weblink';
 $GO_FIELDS['types_id']['name']          = __("Type");
 $GO_FIELDS['types_id']['linkfield']     = 'type';
 $GO_FIELDS['types_id']['input_type']    = 'dropdown';
-// The 'isolated' dropdown type will create a isolated table for each type that will be assigned
-// with this field.
 $GO_FIELDS['types_id']['dropdown_type'] = 'isolated';
 
 $GO_FIELDS['models_id']['name']          = __("Model");

--- a/fields/field.constant.php
+++ b/fields/field.constant.php
@@ -51,6 +51,7 @@ $GO_FIELDS['otherserial']['autoname']   = true;
 $GO_FIELDS['comment']['name']       = __("Comments");
 $GO_FIELDS['comment']['field']      = 'comment';
 $GO_FIELDS['comment']['input_type'] = 'multitext';
+$GO_FIELDS['gestion']['colums']     = '3'; //[CRI] : colums - Add colspan on formulary			 			   
 
 $GO_FIELDS['other']['name']         = __("Others");
 $GO_FIELDS['other']['input_type']   = 'text';
@@ -147,3 +148,14 @@ $GO_FIELDS['contact_num']['input_type'] = 'text';
 $GO_FIELDS['groups_id_tech']['name']       = __("Group in charge of the hardware");
 $GO_FIELDS['groups_id_tech']['input_type'] = 'dropdown';
 $GO_FIELDS['groups_id_tech']['condition']  = ['is_assign' => 1];
+
+//*****//
+// INICIO [CRI] : section - Add section on formulary
+//*****//	
+$GO_FIELDS['section']['name']       = __("Example secction");
+$GO_FIELDS['section']['field']      = 'sectionRow';
+$GO_FIELDS['section']['input_type'] = 'sectionRow';
+$GO_FIELDS['section']['colums']     = '4'; 
+//*****//
+// FINAL [CRI] : section - Add section on formulary
+//*****//	

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -393,6 +393,15 @@ class PluginGenericobjectField extends CommonDBTM {
             case 'decimal' :
                $query .= "DECIMAL(20,4) NOT NULL DEFAULT '0.0000'";
                break;
+            //*****//
+            // INICIO [CRI] : section - Add section on formulary
+            //*****//				   
+            case 'sectionRow' :
+               $query .= "VARCHAR(45) NULL DEFAULT 'Section'";
+               break;	
+            //*****//
+            // FINAL [CRI] : section - Add section on formulary
+            //*****//	               
          }
          if ($after) {
             $query.=" AFTER `$after`";


### PR DESCRIPTION
Add section on formulary:

$GO_FIELDS['section']['name']       = __("Example secction");
$GO_FIELDS['section']['field']      = 'sectionRow';
$GO_FIELDS['section']['input_type'] = 'sectionRow';
$GO_FIELDS['section']['colums']     = '4';

Add Colspan on formulary:

$GO_FIELDS['comment']['name']       = __("Comments");
$GO_FIELDS['comment']['field']      = 'comment';
$GO_FIELDS['comment']['input_type'] = 'multitext';
$GO_FIELDS['gestion']['colums']     = '3'; //[CRI] : colums - Add colspan on formulary