### PR TITLE
fix typo breaking cloning feature

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -84,7 +84,7 @@ class PluginGenericobjectObject extends CommonDBTM {
          Contract_Item::class,
          Document_Item::class,
          Infocom::class,
-         Item_devices::class,
+         Item_Devices::class,
          NetworkPort::class,
       ];
    }


### PR DESCRIPTION
When trying to clone an instance of an object (which use Assistance) then a warning is displayed and logged.

```
[2023-05-12 15:02:13] glpiphplog.WARNING:   *** PHP User Warning (512): Unable to clone elements of class Item_devices as it does not extends "CommonDBConnexity" in /home/bugier/public_html/glpi-100a/src/Features/Clonable.php at line 112
  Backtrace :
  src/Features/Clonable.php:112                      trigger_error()
  src/Features/Clonable.php:241                      PluginGenericobjectObject->cloneRelations()
  src/Features/Clonable.php:190                      PluginGenericobjectObject->clone()
  src/MassiveAction.php:1658                         PluginGenericobjectObject->cloneMultiple()
  src/MassiveAction.php:1408                         MassiveAction::processMassiveActionsForOneItemtype()
  src/MassiveAction.php:1386                         MassiveAction->processForSeveralItemtypes()
  front/massiveaction.php:59                         MassiveAction->process()
```