### PR TITLE
Fix menu entries ordering

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -1260,7 +1260,12 @@ class PluginGenericobjectObject extends CommonDBTM {
          }
       }
 
+      // Sort by menu entries name
+      uasort($menu, fn($a, $b) => $a['title'] <=> $b['title']);
+
+      // Mark as multi entries
       $menu['is_multi_entries']= true;
+
       return $menu;
    }
 


### PR DESCRIPTION
Before:
![image](https://github.com/pluginsGLPI/genericobject/assets/42734840/c7b8411d-a360-4b79-bd00-47afc7397ed4)

After:
![image](https://github.com/pluginsGLPI/genericobject/assets/42734840/04dfbf49-4e96-4663-a168-12c935c805db)


This happens be we fetch all items (ordered by name) then group them by their family.
The ordering should be done on the family names instead, which can be easily done by sorting the final menu entries.