### PR TITLE
fix(core): prevent uasort(): Argument #1 () must be of type array, null given

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -1235,6 +1235,7 @@ class PluginGenericobjectObject extends CommonDBTM {
                }
             }
 
+            $menu = [];
             if ($type['plugin_genericobject_typefamilies_id'] > 0
                && (!isset($_GET['itemtype'])
                   || !preg_match("/itemtype=".$_GET['itemtype']."/", $_GET['itemtype']))) {


### PR DESCRIPTION
Prevent this

```
[2023-09-15 14:28:05] glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: uasort(): Argument #1 ($array) must be of type array, null given in /mnt/diskhome/home/htdocs/marketplace/genericobject/inc/object.class.php at line 1264
  Backtrace :
  ...etplace/genericobject/inc/object.class.php:1264 uasort()
  src/Html.php:1454                                  PluginGenericobjectObject::getMenuContent()
  src/Html.php:1681                                  Html::generateMenuSession()
  front/central.php:82                               Html::header()
```

When no family or object has been created (i.e. from installation)

A release will become essential