### PR TITLE
fix(lang): reset lang before construct searchoption

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -288,7 +288,6 @@ class PluginGenericobjectField extends CommonDBTM {
    static function getFieldOptions($field, $itemtype = "") {
       global $GO_FIELDS;
 
-
       $options = [];
       $cleaned_field = preg_replace("/^plugin_genericobject_/", '', $field);
       if (!isset($GO_FIELDS[$cleaned_field]) && !empty($itemtype)) {

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -288,6 +288,9 @@ class PluginGenericobjectField extends CommonDBTM {
    static function getFieldOptions($field, $itemtype = "") {
       global $GO_FIELDS;
 
+      $GO_FIELDS = [];
+      plugin_genericobject_includeCommonFields(true);
+
       $options = [];
       $cleaned_field = preg_replace("/^plugin_genericobject_/", '', $field);
       if (!isset($GO_FIELDS[$cleaned_field]) && !empty($itemtype)) {

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -288,8 +288,6 @@ class PluginGenericobjectField extends CommonDBTM {
    static function getFieldOptions($field, $itemtype = "") {
       global $GO_FIELDS;
 
-      $GO_FIELDS = [];
-      plugin_genericobject_includeCommonFields(true);
 
       $options = [];
       $cleaned_field = preg_replace("/^plugin_genericobject_/", '', $field);

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -861,6 +861,9 @@ class PluginGenericobjectObject extends CommonDBTM {
       // Prevent usage of reserved and blacklisted indexes
       $taken_indexes = array_merge($index_exceptions, $blacklisted_indexes);
 
+      $GO_FIELDS = [];
+      plugin_genericobject_includeCommonFields(true);
+
       foreach (PluginGenericobjectSingletonObjectField::getInstance(get_called_class())
          as $field => $values
       ) {

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -861,7 +861,6 @@ class PluginGenericobjectObject extends CommonDBTM {
       // Prevent usage of reserved and blacklisted indexes
       $taken_indexes = array_merge($index_exceptions, $blacklisted_indexes);
 
-      $GO_FIELDS = [];
       plugin_genericobject_includeCommonFields(true);
 
       foreach (PluginGenericobjectSingletonObjectField::getInstance(get_called_class())


### PR DESCRIPTION
```FormCreator``` allows you to use a ```tag``` targeting a property of the selected object (in a question)

ex : 

```##answer_1.Serial_number##```

To do this, ```Formcreator``` changes language (```en_GB```) and load plugin languages to search for the property in ```searchOption```

See : https://github.com/pluginsGLPI/formcreator/pull/3367

Even if you change your language, the plugin will not take this into account. 

Because ```$GO_FIELDS``` is already computed with the language of the logged-in user

This PR forces the system to compute ```$GO_FIELD``` as soon as it requests the ```searchOption```