### PR TITLE
fix(Impact): remove backslash added twice

### DIFF
--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -2796,7 +2796,7 @@ class PluginGenericobjectType extends CommonDBTM
         $path = GLPI_PLUGIN_DOC_DIR . "/genericobject/impact_icons/$filename";
 
         if ($relative) {
-            $path = str_replace(GLPI_ROOT, "", $path);
+            $path = str_replace(GLPI_ROOT."/", "", $path);
         }
 
         return $path;


### PR DESCRIPTION
Icon from genericobject is badly display from GLPI impact analysis

![image](https://github.com/pluginsGLPI/genericobject/assets/7335054/321b308b-5367-438d-b0d1-786913163811)

See relative path containing a double backslash

Clean relative icon path by removing extra backslash 

as is already added by glpi core

https://github.com/glpi-project/glpi/blob/5d510f7cb9cd775a9477f98059a8e7569e2f904c/src/Impact.php#L1029

