### PR TITLE
Fix(Object): fix rightname computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Fix ```rightname``` computation
+
 
 ## [2.14.9] - 2024-04-02
 

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -69,7 +69,7 @@ class PluginGenericobjectObject extends CommonDBTM
         if (preg_match("/PluginGenericobject(.*)/", $class, $results)) {
             if (preg_match("/^(.*)y$/i", $results[1], $end_results)) {
                 static::$rightname = 'plugin_genericobject_' . strtolower($end_results[1]) . 'ies';
-            } else if (preg_match("/^(.*)ss$/i", $results[1])) {
+            } else if (preg_match("/^(.*)(ss|x)$/i", $results[1])) {
                 static::$rightname = 'plugin_genericobject_' . strtolower($results[1]) . 'es';
             } else {
                 static::$rightname = 'plugin_genericobject_' . strtolower($results[1]) . 's';


### PR DESCRIPTION
In GLPI, objects ending with ```x``` (e.g. ```PAX```) automatically have their table suffixed with ```es```.

cf ```DbUtils::getPlural()```

In ```GenericObject```, the ```rightname``` computation follows part of this logic
But the case of the object ending with ```x``` is missing.

An object ```PluginGenericObjectPax``` have a table like ```plugin_genericobject_paxes``` (OK) but ```rightname```  is compute as ```plugin_genericobject_paxs``` (NOK) 

for classic use, with only the ```Genericobject``` plugin, rights management is OK

But when plugin ```fields``` create a container (from template) for ```PluginGenericObjectPax```, bad ```rightname``` is used (```plugin_genericobject_paxs```)

And when ```datainjection``` plugin have to handle fields (from ```fields``` plugin) , plugin refuse to display related model because current user have no right (on ```plugin_genericobject_paxes``` but have on ```plugin_genericobject_paxs```)
