### PR TITLE
fix: map search

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -872,7 +872,7 @@ class PluginGenericobjectObject extends CommonDBTM
     public function rawSearchOptions()
     {
         $datainjection_blacklisted = ['id', 'date_mod', 'entities_id', 'date_creation'];
-        $index_exceptions = ['name' => 1, 'id' => 2, 'comment' => 16, 'date_mod' => 19,
+        $index_exceptions = ['name' => 1, 'id' => 2, 'completename' => 3, 'comment' => 16, 'date_mod' => 19,
             'entities_id' => 80, 'is_recursive' => 86, 'notepad' => 90,
             'date_creation' => 121
         ];
@@ -892,7 +892,7 @@ class PluginGenericobjectObject extends CommonDBTM
 
         $index   = 3;
 
-        $options = [];
+        $options = \Location::rawSearchOptionsToAdd();
 
         $options[] = [
             'id'   => 'common',


### PR DESCRIPTION
Searching on plugin objects with the map view didn't work, as longitude nor latitude wasn't retrieved.

ref !33107