### PR TITLE
Fix(Local): fix local override by adding missing global scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix ```rightname``` computation
+- Fix local override management
 
 
 ## [2.14.9] - 2024-04-02

--- a/objects/locale.tpl
+++ b/objects/locale.tpl
@@ -24,5 +24,6 @@
  @link      http://www.glpi-project.org/
  @since     2009
  ---------------------------------------------------------------------- */
+global $LANG;
 
 $LANG['genericobject']['%%CLASSNAME%%'][0]="%%NAME%%";


### PR DESCRIPTION
Even if, before including the locale file, the plugin calls ```global $LANG```, 

translations are not added to ```$LANG``` (```array```)

You also need to add the ```global $LANG``` to the locale file
 

This PR adapt the template used to create locale file