### PR TITLE
Fix(Core): remove uselss and non-functional injection

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -247,10 +247,6 @@ class PluginGenericobjectObject extends CommonDBTM
                     array_push($CFG_GLPI['asset_types'], $class);
                 }
 
-                if (!in_array($class, $CFG_GLPI['state_types'])) {
-                    array_push($CFG_GLPI['state_types'], $class);
-                }
-
                 if (!in_array($class, $CFG_GLPI['globalsearch_types'])) {
                     array_push($CFG_GLPI['globalsearch_types'], $class);
                 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Injecting generic objects into `$CFG_GLPI['state_types']` is useless and can't work 

![image](https://github.com/user-attachments/assets/c03d0ddb-ca83-46de-9788-ad39d86046ba)

The corresponding SQL table cannot accept a new `is_visible_xxxx` column (this is GLPI's responsibility in this area).

Updating the field simply doesn't work

```sql
MariaDB [10bugfixes]> explain glpi_states;
+-------------------------------+------------------+------+-----+---------+----------------+
| Field                         | Type             | Null | Key | Default | Extra          |
+-------------------------------+------------------+------+-----+---------+----------------+
| id                            | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
| name                          | varchar(255)     | YES  | MUL | NULL    |                |
| entities_id                   | int(10) unsigned | NO   | MUL | 0       |                |
| is_recursive                  | tinyint(4)       | NO   | MUL | 0       |                |
| comment                       | text             | YES  |     | NULL    |                |
| states_id                     | int(10) unsigned | NO   | MUL | 0       |                |
| completename                  | text             | YES  |     | NULL    |                |
| level                         | int(11)          | NO   | MUL | 0       |                |
| ancestors_cache               | longtext         | YES  |     | NULL    |                |
| sons_cache                    | longtext         | YES  |     | NULL    |                |
| is_visible_computer           | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_monitor            | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_networkequipment   | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_peripheral         | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_phone              | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_printer            | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_softwareversion    | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_softwarelicense    | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_line               | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_certificate        | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_rack               | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_passivedcequipment | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_enclosure          | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_pdu                | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_cluster            | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_contract           | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_appliance          | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_databaseinstance   | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_cable              | tinyint(4)       | NO   | MUL | 1       |                |
| is_visible_unmanaged          | tinyint(4)       | NO   | MUL | 1       |                |
| date_mod                      | timestamp        | YES  | MUL | NULL    |                |
| date_creation                 | timestamp        | YES  | MUL | NULL    |                |
+-------------------------------+------------------+------+-----+---------+----------------+
```

Fix !34853

No CHANGELOG entry as this issue is not is not known (no one paid attention and it doesn't work anyway)

## Screenshots (if appropriate):

