### PR TITLE
fix(TCO): missing ticket_tco field in table object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Improve global performance when using many genericobject
+- The `TCO` (Total Cost of Ownership) is now correctly updated based on the costs associated with an item.
 
 ## [2.14.11] - 2024-12-27
 

--- a/fields/field.constant.php
+++ b/fields/field.constant.php
@@ -116,6 +116,9 @@ $GO_FIELDS['is_global']['massiveaction'] = false;
 $GO_FIELDS['is_helpdesk_visible']['name']       = __("Associable to a ticket");
 $GO_FIELDS['is_helpdesk_visible']['input_type'] = 'bool';
 
+$GO_FIELDS['ticket_tco']['name']       = __("TCO");
+$GO_FIELDS['ticket_tco']['input_type'] = 'decimal';
+
 $GO_FIELDS['locations_id']['name']       = __("Item location");
 $GO_FIELDS['locations_id']['input_type'] = 'dropdown';
 

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -638,7 +638,7 @@ class PluginGenericobjectObject extends CommonDBTM
     public static function getFieldsToHide()
     {
         return ['id', 'is_recursive', 'is_template', 'template_name', 'is_deleted',
-            'entities_id', 'notepad', 'date_mod', 'date_creation'
+            'entities_id', 'notepad', 'date_mod', 'date_creation', 'ticket_tco'
         ];
     }
 

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1102,7 +1102,6 @@ class PluginGenericobjectType extends CommonDBTM
            //TODO rename is_helpdesk_visible into is_helpdeskvisible
             PluginGenericobjectField::addNewField($table, 'is_helpdesk_visible', 'comment');
             PluginGenericobjectField::addNewField($table, 'ticket_tco');
-
         } else {
             PluginGenericobjectField::deleteField($table, 'is_helpdesk_visible');
         }

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -2488,10 +2488,11 @@ class PluginGenericobjectType extends CommonDBTM
         }
 
         $types = new self();
-        $object_use_infocoms = $types->getFromDBByCrit(['use_infocoms' => 1]);
+        $object_use_infocoms = $types->find(['use_infocoms' => 1]);
         foreach ($object_use_infocoms as $object) {
-            $object_table = $object->getTable();
+            $object_table = $object['itemtype']::getTable();
             $migration->addField($object_table, "ticket_tco", "decimal");
+            $migration->migrationOneTable($object_table);
         }
     }
 

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1101,6 +1101,8 @@ class PluginGenericobjectType extends CommonDBTM
         if ($this->canUseTickets()) {
            //TODO rename is_helpdesk_visible into is_helpdeskvisible
             PluginGenericobjectField::addNewField($table, 'is_helpdesk_visible', 'comment');
+            PluginGenericobjectField::addNewField($table, 'ticket_tco');
+
         } else {
             PluginGenericobjectField::deleteField($table, 'is_helpdesk_visible');
         }

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -2486,6 +2486,13 @@ class PluginGenericobjectType extends CommonDBTM
                 $preference->add($tmp);
             }
         }
+
+        $types = new self();
+        $object_use_infocoms = $types->getFromDBByCrit(['use_infocoms' => 1]);
+        foreach ($object_use_infocoms as $object) {
+            $object_table = $object->getTable();
+            $migration->addField($object_table, "ticket_tco", "decimal");
+        }
     }
 
 

--- a/setup.php
+++ b/setup.php
@@ -117,12 +117,12 @@ function plugin_init_genericobject()
     global $PLUGIN_HOOKS, $GO_BLACKLIST_FIELDS,
           $GENERICOBJECT_PDF_TYPES, $GO_LINKED_TYPES, $GO_READONLY_FIELDS, $CFG_GLPI;
 
-    $GO_READONLY_FIELDS  =  ["is_helpdesk_visible", "comment"];
+    $GO_READONLY_FIELDS  =  ["is_helpdesk_visible", "comment", "ticket_tco"];
 
     $GO_BLACKLIST_FIELDS =  ["itemtype", "table", "is_deleted", "id", "entities_id",
         "is_recursive", "is_template", "notepad", "template_name",
         "date_mod", "name", "is_helpdesk_visible", "comment",
-        "date_creation"
+        "date_creation", "ticket_tco"
     ];
 
     $GO_LINKED_TYPES     =  ['Computer', 'Phone', 'Peripheral', 'Software', 'Monitor',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.

## Description

- It fixes !34818
- adds the ticket_tco field to the table of each object when the user wants to use tickets. This fixes the bug that prevent TCO from being calculated for genericobject.

