### PR TITLE
2.14.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [2.14.11] - 2024-12-17
+## [2.14.11] - 2024-12-27
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.14.11] - 2024-12-17
+
 ### Fixed
 
 - Fix `Use Components` to display all components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix `Use Components` to display all components
-
-### Fixed
-
--  Hide `items` without proper user access rights in the family list.
+- Hide `items` without proper user access rights in the family list.
 
 ## [2.14.10] - 2024-09-06
 

--- a/genericobject.xml
+++ b/genericobject.xml
@@ -25,6 +25,11 @@
    </authors>
    <versions>
       <version>
+         <num>2.14.11</num>
+         <compatibility>~10.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/genericobject/releases/download/2.14.11/glpi-genericobject-2.14.11.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.14.10</num>
          <compatibility>~10.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/genericobject/releases/download/2.14.10/glpi-genericobject-2.14.10.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_GENERICOBJECT_VERSION', '2.14.10');
+define('PLUGIN_GENERICOBJECT_VERSION', '2.14.11');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_GENERICOBJECT_MIN_GLPI", "10.0.0");


### PR DESCRIPTION
## [2.14.11] - 2024-12-17

### Fixed

- Fix `Use Components` to display all components
- Hide `items` without proper user access rights in the family list.