### PR TITLE
perf: improve global performance when using many genericobject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve global performance when using many genericobject
+
 ## [2.14.11] - 2024-12-27
 
 ### Fixed

--- a/setup.php
+++ b/setup.php
@@ -218,10 +218,14 @@ function plugin_post_init_genericobject()
         ['addtabon' => ['Profile', 'PluginGenericobjectType']]
     );
 
+
     foreach (PluginGenericobjectType::getTypes() as $id => $objecttype) {
         $itemtype = $objecttype['itemtype'];
         if (class_exists($itemtype)) {
-            $itemtype::registerType();
+            if (!isset($_SESSION['glpi_plugin']['genericobject']['registeredtype'][$itemtype])) {
+                $_SESSION['glpi_plugin']['genericobject']['registeredtype'][$itemtype] = $itemtype;
+                $itemtype::registerType();
+            }
         }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35986

improve global performance when using many genericobject



When a GLPI page is loaded (depending of context) a itemtype created by genericobject can be registered at least 9 times (see on ticket page)

With 200 object -> 1800 `registerType` call ..

So before `registerType` (which done many action) check if already register in `$_SESSION`

Before 

![image](https://github.com/user-attachments/assets/5a0dd665-d90b-414e-83b7-76a3e4c11383)

After 

![image](https://github.com/user-attachments/assets/6ded0ed8-62b7-47f3-8f28-0b70f07d6470)


## Screenshots (if appropriate):

