### PR TITLE
Fix(core): revert commit for improve perf

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -170,42 +170,6 @@ class PluginGenericobjectObject extends CommonDBTM
         $fields = PluginGenericobjectSingletonObjectField::getInstance($class);
         $plugin = new Plugin();
 
-        if (isset($_SESSION['glpi_plugin']['genericobject']['registeredtype'][$class])) {
-            // register the itemtype  if needed
-            // because some of $CFG_GLPI['xxxxxxxxxxx_types'] are reset at each reload
-            if ($item->canBeReserved()) {
-                $CFG_GLPI['reservation_types'][$class] = $class;
-            }
-
-            if ($item->canUseNetworkPorts()) {
-                $CFG_GLPI['networkport_types'][$class] = $class;
-            }
-
-            if ($item->canUseItemDevice()) {
-                $CFG_GLPI['itemdevices_types'][$class]              = $class;
-                $CFG_GLPI['itemdevicepowersupply_types'][$class]    = $class;
-                $CFG_GLPI['itemdevicememory_types'][$class]         = $class;
-                $CFG_GLPI['itemdevicenetworkcard_types'][$class]    = $class;
-                $CFG_GLPI['itemdeviceharddrive_types'][$class]      = $class;
-                $CFG_GLPI['itemdevicebattery_types'][$class]        = $class;
-                $CFG_GLPI['itemdevicefirmware_types'][$class]       = $class;
-                $CFG_GLPI['itemdevicesimcard_types'][$class]        = $class;
-                $CFG_GLPI['itemdevicegeneric_types'][$class]        = $class;
-                $CFG_GLPI['itemdevicepci_types'][$class]            = $class;
-                $CFG_GLPI['itemdevicesensor_types'][$class]         = $class;
-                $CFG_GLPI['itemdeviceprocessor_types'][$class]      = $class;
-                $CFG_GLPI['itemdevicesoundcard_types'][$class]      = $class;
-                $CFG_GLPI['itemdevicegraphiccard_types'][$class]    = $class;
-                $CFG_GLPI['itemdevicemotherboard_types'][$class]    = $class;
-                $CFG_GLPI['itemdevicecamera_types'][$class]         = $class;
-                $CFG_GLPI['itemdevicedrive_types'][$class]          = $class;
-                $CFG_GLPI['itemdevicecontrol_types'][$class]        = $class;
-            }
-            return;
-        } else {
-            $_SESSION['glpi_plugin']['genericobject']['registeredtype'][$class] = $class;
-        }
-
         PluginGenericobjectType::includeLocales($item->getObjectTypeName());
         PluginGenericobjectType::includeConstants($item->getObjectTypeName());
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since https://github.com/pluginsGLPI/genericobject/pull/417/files


Trying to handle the `register` of `GenericObject` instances through **SESSION** is currently not the appropriate approach.

As it stands, GLPI resets many values in `$CFG_GLPI`, which forces us to reprocess them each time we check whether they're stored in the session.

https://github.com/pluginsGLPI/genericobject/pull/427
https://github.com/pluginsGLPI/genericobject/pull/426
https://github.com/pluginsGLPI/genericobject/pull/420
https://github.com/pluginsGLPI/genericobject/pull/418

I therefore suggest we simply **revert** this change.

The issue only affects a single instance — even though it makes intensive and industrial use of the plugin. Moreover, with native *genericity* now available in GLPI, a new and more optimized loading mechanism is provided, making the plugin's approach obsolete.


## Screenshots (if appropriate):

