### PR TITLE
2.14.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [2.14.13] - 2025-04-22
+## [2.14.14] - 2025-04-23
 
 ### Fixed
 
 - Prevent PHP warning about unknown option `itemdevicedrive_types` and `itemdevicecontrol_types` when registering type
+
+## [2.14.13] - 2025-04-22
 
 ### Fixed
 

--- a/genericobject.xml
+++ b/genericobject.xml
@@ -25,6 +25,11 @@
    </authors>
    <versions>
       <version>
+         <num>2.14.14</num>
+         <compatibility>~10.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/genericobject/releases/download/2.14.14/glpi-genericobject-2.14.14.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.14.13</num>
          <compatibility>~10.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/genericobject/releases/download/2.14.13/glpi-genericobject-2.14.13.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_GENERICOBJECT_VERSION', '2.14.13');
+define('PLUGIN_GENERICOBJECT_VERSION', '2.14.14');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_GENERICOBJECT_MIN_GLPI", "10.0.0");


### PR DESCRIPTION
## [2.14.14] - 2025-04-23

### Fixed

- Prevent PHP warning about unknown option `itemdevicedrive_types` and `itemdevicecontrol_types` when registering type