### PR TITLE
fix(fields): massive actions with Fields plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix massive actions compatibility with Fields plugin
+
 ## [2.14.14] - 2025-04-23
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
+        "glpi-project/phpstan-glpi": "^1.0",
         "glpi-project/tools": "^0.7.5",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d6cf27f3edf20c177140ee4bfed39fc",
+    "content-hash": "31a02686fa4587fa1891c4b7b55d0f67",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "glpi-project/phpstan-glpi",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/glpi-project/phpstan-glpi.git",
+                "reference": "432f7a10d221f60abdbd4ab4676dbd846a485df1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/glpi-project/phpstan-glpi/zipball/432f7a10d221f60abdbd4ab4676dbd846a485df1",
+                "reference": "432f7a10d221f60abdbd4ab4676dbd846a485df1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "phpstan/phpstan": "^2.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStanGlpi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for GLPI.",
+            "support": {
+                "issues": "https://github.com/glpi-project/phpstan-glpi/issues",
+                "source": "https://github.com/glpi-project/phpstan-glpi/tree/1.0.0"
+            },
+            "time": "2025-06-24T11:45:31+00:00"
+        },
         {
             "name": "glpi-project/tools",
             "version": "0.7.5",
@@ -1293,5 +1341,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/hook.php
+++ b/hook.php
@@ -212,3 +212,18 @@ function plugin_genericobject_MassiveActions($type)
         return [];
     }
 }
+
+function plugin_genericobject_MassiveActionsFieldsDisplay($options = [])
+{
+    if (!Plugin::isPluginActive('fields')) {
+        return false;
+    }
+
+    $itemtypes = PluginFieldsContainer::getEntries('all');
+
+    if (in_array($options['itemtype'], $itemtypes)) {
+        return PluginFieldsField::showSingle($options['itemtype'], $options['options'], true);
+    }
+
+    return false;
+}

--- a/hook.php
+++ b/hook.php
@@ -219,6 +219,14 @@ function plugin_genericobject_MassiveActionsFieldsDisplay($options = [])
         return false;
     }
 
+    if (!class_exists('PluginFieldsContainer') || !method_exists('PluginFieldsContainer', 'getEntries')) {
+        return false;
+    }
+
+    if (!class_exists('PluginFieldsField') || !method_exists('PluginFieldsField', 'showSingle')) {
+        return false;
+    }
+
     $itemtypes = PluginFieldsContainer::getEntries('all');
 
     if (in_array($options['itemtype'], $itemtypes)) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,5 +15,7 @@ parameters:
         - ../../src
     stubFiles:
         - ../../stubs/glpi_constants.php
+    ignoreErrors:
+        - '#Call to .* on an unknown class PluginFields*#'
 rules:
     - GlpiProject\Tools\PHPStan\Rules\GlobalVarTypeRule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,7 +15,3 @@ parameters:
         - ../../src
     stubFiles:
         - ../../stubs/glpi_constants.php
-    ignoreErrors:
-        - '#Call to .* on an unknown class PluginFields*#'
-rules:
-    - GlpiProject\Tools\PHPStan\Rules\GlobalVarTypeRule


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38333
- Fields added via the fields plugin to an object coming from the genericobject plugin could not be modified if the user passed through massive actions.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/07db92e6-889c-4707-bf04-4aa8223e849c)


