### PR TITLE
Chore(i18n): update translations

### DIFF
--- a/fields/field.constant.php
+++ b/fields/field.constant.php
@@ -135,7 +135,7 @@ $GO_FIELDS['groups_id']['condition']  = ['is_itemgroup' => 1];
 $GO_FIELDS['manufacturers_id']['name']       = __("Manufacturer");
 $GO_FIELDS['manufacturers_id']['input_type'] = 'dropdown';
 
-$GO_FIELDS['users_id_tech']['name']       = __("Technician in charge of the hardware");
+$GO_FIELDS['users_id_tech']['name']       = __("Technician in charge");
 $GO_FIELDS['users_id_tech']['input_type'] = 'dropdown';
 
 $GO_FIELDS['domains_id']['name']       = __("Domain");
@@ -147,6 +147,6 @@ $GO_FIELDS['contact']['input_type'] = 'text';
 $GO_FIELDS['contact_num']['name']       = __("Alternate username number");
 $GO_FIELDS['contact_num']['input_type'] = 'text';
 
-$GO_FIELDS['groups_id_tech']['name']       = __("Group in charge of the hardware");
+$GO_FIELDS['groups_id_tech']['name']       = __("Group in charge");
 $GO_FIELDS['groups_id_tech']['input_type'] = 'dropdown';
 $GO_FIELDS['groups_id_tech']['condition']  = ['is_assign' => 1];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #38434

The translations **"Technician in charge of the hardware"** and **"Group in charge of the hardware"** originated from GLPI but no longer exist in the current core.

As a result, they are no longer translated in the plugin.

This PR addresses the issue by referencing the correct gettext translation keys from the updated GLPI core.


## Screenshots (if appropriate):

